### PR TITLE
Fix status badge selector by device id

### DIFF
--- a/resources/js/services/device-status-handler.js
+++ b/resources/js/services/device-status-handler.js
@@ -23,7 +23,9 @@ export class DeviceStatusHandler {
 
     updateUI(deviceId, data) {
         // Update status badge
-        const statusBadges = document.querySelectorAll('.device-status-badge, .status-badge');
+        const statusBadges = document.querySelectorAll(
+            `[data-device-id="${deviceId}"] .device-status-badge, [data-device-id="${deviceId}"] .status-badge`
+        );
         statusBadges.forEach(badge => {
             badge.className = `badge ${data.is_online ? 'bg-success' : 'bg-danger'} device-status-badge`;
             badge.innerHTML = `


### PR DESCRIPTION
## Summary
- restrict status badge updates to the current device only

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bf4b3526c832c8bf222119c96f43e