### PR TITLE
Add Pin chart data test

### DIFF
--- a/app/Http/Controllers/PinController.php
+++ b/app/Http/Controllers/PinController.php
@@ -468,6 +468,11 @@ class PinController extends Controller
         return response()->json($data);
     }
 
+    public function chartData(Request $request, Pin $pin)
+    {
+        return $this->getChartData($request, $pin);
+    }
+
     public function getChartData(Request $request, Pin $pin)
     {
         try {

--- a/database/migrations/2024_05_30_135222_modify_pins_type_column.php
+++ b/database/migrations/2024_05_30_135222_modify_pins_type_column.php
@@ -9,18 +9,26 @@ return new class extends Migration
 {
     public function up()
     {
+        if (Schema::getConnection()->getDriverName() === 'sqlite') {
+            return;
+        }
+
         // First, drop the enum constraint
         DB::statement("ALTER TABLE pins MODIFY COLUMN type VARCHAR(50)");
-        
+
         // Then update existing records if needed
         DB::table('pins')->whereIn('type', ['digital_input', 'digital_output', 'analog_input'])->update([
-            'type' => DB::raw('type') // Keep existing values
+            'type' => DB::raw('type'), // Keep existing values
         ]);
     }
 
     public function down()
     {
+        if (Schema::getConnection()->getDriverName() === 'sqlite') {
+            return;
+        }
+
         // Convert back to enum
         DB::statement("ALTER TABLE pins MODIFY COLUMN type ENUM('digital_input', 'digital_output', 'analog_input', 'ph_sensor')");
     }
-}; 
+};

--- a/database/migrations/2024_05_30_create_pins_table.php
+++ b/database/migrations/2024_05_30_create_pins_table.php
@@ -9,10 +9,14 @@ return new class extends Migration
 {
     public function up()
     {
+        if (Schema::getConnection()->getDriverName() === 'sqlite') {
+            return;
+        }
+
         Schema::table('pins', function (Blueprint $table) {
             // First convert to varchar to avoid enum constraints
             DB::statement("ALTER TABLE pins MODIFY COLUMN type VARCHAR(50)");
-            
+
             // Then update the type to include ph_sensor
             DB::statement("UPDATE pins SET type = 'ph_sensor' WHERE type = 'analog_input' AND name LIKE '%pH%'");
         });
@@ -20,9 +24,13 @@ return new class extends Migration
 
     public function down()
     {
+        if (Schema::getConnection()->getDriverName() === 'sqlite') {
+            return;
+        }
+
         Schema::table('pins', function (Blueprint $table) {
             DB::statement("UPDATE pins SET type = 'analog_input' WHERE type = 'ph_sensor'");
             DB::statement("ALTER TABLE pins MODIFY COLUMN type ENUM('digital_input', 'digital_output', 'analog_input', 'analog_output') NOT NULL");
         });
     }
-}; 
+};

--- a/database/migrations/2025_06_01_085051_add_user_id_to_devices_table.php
+++ b/database/migrations/2025_06_01_085051_add_user_id_to_devices_table.php
@@ -12,6 +12,13 @@ return new class extends Migration
      */
     public function up(): void
     {
+        if (Schema::getConnection()->getDriverName() === 'sqlite') {
+            Schema::table('devices', function (Blueprint $table) {
+                $table->unsignedBigInteger('user_id')->after('id')->nullable();
+            });
+            return;
+        }
+
         Schema::table('devices', function (Blueprint $table) {
             $table->unsignedBigInteger('user_id')->after('id')->nullable();
         });

--- a/tests/Feature/PinChartDataTest.php
+++ b/tests/Feature/PinChartDataTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Project;
+use App\Models\Device;
+use App\Models\Pin;
+use App\Models\PinLog;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Carbon\Carbon;
+use Tests\TestCase;
+
+class PinChartDataTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_fetch_pin_chart_data()
+    {
+        $user = User::factory()->create();
+
+        $project = Project::create([
+            'user_id' => $user->id,
+            'name' => 'Test Project',
+            'description' => 'Project for testing',
+        ]);
+
+        $device = Device::create([
+            'project_id' => $project->id,
+            'name' => 'Test Device',
+            'description' => 'Device for testing',
+            'device_key' => 'test-key',
+            'is_online' => false,
+            'last_online' => now(),
+        ]);
+        // assign user id separately as it's not mass assignable
+        $device->user_id = $user->id;
+        $device->save();
+
+        $pin = Pin::create([
+            'device_id' => $device->id,
+            'name' => 'Test Pin',
+            'pin_number' => 1,
+            'type' => 'analog_input',
+            'is_active' => true,
+        ]);
+
+        foreach (range(1, 3) as $i) {
+            PinLog::create([
+                'pin_id' => $pin->id,
+                'value' => $i,
+                'raw_value' => $i * 10,
+                'created_at' => Carbon::now()->subMinutes(3 - $i),
+                'updated_at' => Carbon::now()->subMinutes(3 - $i),
+            ]);
+        }
+
+        $response = $this->actingAs($user)->getJson("/api/pins/{$pin->uuid}/chart-data");
+
+        $response->assertStatus(200)
+                 ->assertJsonStructure([
+                     'timestamps',
+                     'values',
+                     'stats',
+                 ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add feature test for pin chart data API
- update migrations to skip incompatible SQL on sqlite
- add chartData wrapper method in PinController for route compatibility

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_684bf7600a40832c81b8c9d9d81b1f8d